### PR TITLE
Add CMake option to build for maximum 8 players

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ if (NOT DEFINED STEAMWORKS_ENABLED)
 	endif()
 endif()
 
+if (DEFINED ENV{BARONY_SUPER_MULTIPLAYER})
+	set (BARONY_SUPER_MULTIPLAYER $ENV{BARONY_SUPER_MULTIPLAYER})
+endif()
+
+option(BARONY_SUPER_MULTIPLAYER "Enable 8 Player Multiplayer" OFF)
+
 if (DEFINED ENV{OPTIMIZATION_LEVEL})
 	set (OPTIMIZATION_LEVEL $ENV{OPTIMIZATION_LEVEL})
 else()
@@ -192,6 +198,12 @@ if (STEAMWORKS_ENABLED)
 	message("Building with steamworks")
 else()
 	message("Building without steamworks")
+endif()
+
+if (BARONY_SUPER_MULTIPLAYER)
+	message("Building with Barony Super Multiplayer")
+else()
+	message("Building without Barony Super Multiplayer")
 endif()
 
 if (EOS_ENABLED)

--- a/src/Config.hpp.in
+++ b/src/Config.hpp.in
@@ -68,6 +68,8 @@
 	#define PANDORA
 #endif
 
+#cmakedefine BARONY_SUPER_MULTIPLAYER
+
 #if @NOT_DWORD_DEFINED@
 	/*
 	 * https://msdn.microsoft.com/en-us/library/cc230318.aspx


### PR DESCRIPTION
Adds the option `-DBARONY_SUPER_MULTIPLAYER` which can be set to a [CMake true constant](https://cmake.org/cmake/help/latest/command/if.html#constant) (eg. `-DBARONY_SUPER_MULTIPLAYER=ON`)to build for 8 player compatibilty